### PR TITLE
sorry to be late :( I have fix some bugs and add a feature

### DIFF
--- a/src/vue-accordion-partial.vue
+++ b/src/vue-accordion-partial.vue
@@ -1,105 +1,118 @@
 <template>
-	<li :style="liStyles">
+	<li :class="{ 'show' : this.index === this.showIndex }" :style="liStyles" @mouseover="showThis">
 		<a :href="item.url" :style="aStyles">
 			<h2 v-text="item.title" :style="h2Styles"></h2>
 			<p v-text="item.text" :style="pStyles"></p>
 		</a>
-    </li>
+	</li>
 </template>
 <script>
 	export default {
-		props: {
-			item: {
-				type: Object
-			},
-			styles: {
-				type: Object
-			}
-		},
-		computed: {
-			liStyles() {
-				const li = {
-					backgroundImage: 'url(' + this.item.image + ')'
-				};
+	  props: {
+	    item: {
+	      type: Object
+	    },
+	    styles: {
+	      type: Object
+	    },
+	    index: {
+	      type: Number
+	    },
+	    showIndex: {
+	      type: Number
+	    }
+	  },
+	  methods: {
+	    showThis: function() {
+	      this.$emit("popup", this.index);
+	    }
+	  },
+	  computed: {
+	    liStyles() {
+	      const li = {
+	        backgroundImage: "url(" + this.item.image + ")"
+	      };
 
-				if(this.styles && this.styles.li)
-					Object.assign(li, this.styles.li);
+	      if (this.styles && this.styles.li) Object.assign(li, this.styles.li);
 
-				return li;
-			},
-			aStyles() {
-				return this.styles && this.styles.a ? this.styles.a : {};
-			},
-			h2Styles() {
-				return this.styles && this.styles.h2 ? this.styles.h2 : {};
-			},
-			pStyles() {
-				return this.styles && this.styles.p ? this.styles.p : {};
-			}
-		}
-	}
+	      return li;
+	    },
+	    aStyles() {
+	      return this.styles && this.styles.a ? this.styles.a : {};
+	    },
+	    h2Styles() {
+	      return this.styles && this.styles.h2 ? this.styles.h2 : {};
+	    },
+	    pStyles() {
+	      return this.styles && this.styles.p ? this.styles.p : {};
+	    }
+	  }
+	};
 </script>
 <style>
 	.vue-accordion ul li {
-		display: table-cell;
-		vertical-align: bottom;
-		position: relative;
-		width: 50%;
-		background-repeat: no-repeat;
-		background-position: center center;
-		transition: all 500ms ease;
-		height: 100%;
-    }
+	  display: table-cell;
+	  vertical-align: bottom;
+	  position: relative;
+	  width: 15%;
+	  background-repeat: no-repeat;
+	  background-position: center center;
+	  transition: all 500ms ease;
+	  height: 100%;
+	}
 
-    .vue-accordion ul li a {
-		display: block;
-		width: 100%;
-		position: relative;
-		z-index: 3;
-		vertical-align: bottom;
-		padding: 15px 20px;
-		box-sizing: border-box;
-		color: #fff;
-		text-decoration: none;
-		transition: all 200ms ease;
-		height: 100%;
-    }
+	.vue-accordion ul li a {
+	  display: block;
+	  width: 100%;
+	  position: relative;
+	  z-index: 3;
+	  padding: 15px 20px;
+	  box-sizing: border-box;
+	  color: #fff;
+	  text-decoration: none;
+	  transition: all 200ms ease;
+	  height: 100%;
+	}
 
-    .vue-accordion ul li a * {
-		opacity: 0;
-		margin: 0;
-		width: 100%;
-		text-overflow: ellipsis;
-		position: relative;
-		z-index: 5;
-		white-space: nowrap;
-		overflow: hidden;
-		-webkit-transform: translateX(-20px);
-		transform: translateX(-20px);
-		-webkit-transition: all 400ms ease;
-		transition: all 400ms ease;
-    }
+	.vue-accordion ul li a * {
+	  opacity: 0;
+	  margin: 0;
+	  width: 100%;
+	  text-overflow: ellipsis;
+	  position: relative;
+	  z-index: 5;
+	  white-space: nowrap;
+	  overflow: hidden;
+	  -webkit-transform: translateX(-60px);
+	  transform: translateX(-60px);
+	  -webkit-transition: all 400ms ease;
+	  transition: all 400ms ease;
+	}
 
-    .vue-accordion ul li a h2 {
-		text-overflow: clip;
-		font-size: 24px;
-		text-transform: uppercase;
-		margin-bottom: 2px;
-    }
+	.vue-accordion ul li a h2 {
+	  text-overflow: clip;
+	  font-size: 24px;
+	  text-transform: uppercase;
+	  margin-bottom: 2px;
+	}
 
-    .vue-accordion ul li a p {
-		font-size: 13.5px;
-    }
+	.vue-accordion ul li a p {
+	  font-size: 13.5px;
+	}
 
-    .vue-accordion ul:hover li { width: 15%; }
-
-    .vue-accordion ul:hover li:hover { width: 60%; }
-
-    .vue-accordion ul:hover li:hover a { background: rgba(0, 0, 0, 0.4); }
-
-    .vue-accordion ul:hover li:hover a * {
-		opacity: 1;
-		-webkit-transform: translateX(0);
-		transform: translateX(0);
-    }
+	.vue-accordion ul li.show {
+	  width: 60%;
+	}
+	
+	.vue-accordion ul li.show a {
+	  background: -webkit-linear-gradient(0deg, rgba(0, 0, 0, 0.8), rgba(0, 0, 0, 0.2));
+	  background: -o-linear-gradient(0deg, rgba(0, 0, 0, 0.8), rgba(0, 0, 0, 0.2)); 
+	  background: -moz-linear-gradient(0deg, rgba(0, 0, 0, 0.8), rgba(0, 0, 0, 0.2));
+	  background: linear-gradient(0deg, rgba(0, 0, 0, 0.8), rgba(0, 0, 0, 0.2)); 
+	}
+	.vue-accordion ul li.show a * {
+	  opacity: 1;
+	  -webkit-transform: translateX(0);
+	  transform: translateX(0);
+	}
 </style>

--- a/src/vue-accordion.vue
+++ b/src/vue-accordion.vue
@@ -1,59 +1,72 @@
 <template>
-	<div :class="accordionClass" :style="divStyles">
+	<div class="vue-accordion" :style="divStyles">
 		<ul>
 			<partial-accordion 
 				v-for="(item,index) in items" 
 				:item="item" 
-				:key="index"
+				:key="index" 
+				:index="index" 
+				:showIndex.sync="showIndex" 
 				:styles="styles"
+				@popup="popup"
 			></partial-accordion>
 		</ul>
 	</div>
 </template>
 <script>
-	import partialAccordion from './vue-accordion-partial.vue'
+	import partialAccordion from "./vue-accordion-partial.vue";
 
 	export default {
-		name: 'vue-accordion',
-		props: {
-			items: {
-				type: Array
-			},
-			styles: {
-				type: Object,
-				default: function() {
-					return {}
-				}
-			},
-			accordionClass: {
-				type: String,
-				default: 'vue-accordion'
+	  name: "vue-accordion",
+	  props: {
+	    items: {
+	      type: Array
+	    },
+	    styles: {
+	      type: Object,
+	      default: function() {
+	        return {};
+	      }
+	    },
+			defaultImage: {
+				type: Number,
+				default: 0
 			}
 		},
-		computed: {
-			divStyles() {
-				return this.styles && this.styles.div ? this.styles.div : {};
+		data () {
+			return {
+				showIndex: (this.defaultImage) ? this.defaultImage - 1 : NaN,
 			}
 		},
-		components: {
-			partialAccordion
-		}
-	}
+		methods: {
+			popup: function (val) {
+				this.showIndex = val;
+			}
+		},
+	  computed: {
+	    divStyles() {
+	      return this.styles && this.styles.div ? this.styles.div : {};
+			}
+	  },
+	  components: {
+	    partialAccordion
+	  }
+	};
 </script>
-<style>
+<style scoped>
 	.vue-accordion {
-		width: 100%;
-		overflow: hidden;
-		height: 200px;
-		max-width: 900px;
-    }
+	  width: 100%;
+	  overflow: hidden;
+	  height: 200px;
+	  max-width: 900px;
+	}
 
-    .vue-accordion ul {
-		width: 100%;
-		height: 100%;
-		display: table;
-		table-layout: fixed;
-		margin: 0;
-		padding: 0;
-    }
+	.vue-accordion ul {
+	  width: 100%;
+	  height: 100%;
+	  display: table;
+	  table-layout: fixed;
+	  margin: 0;
+	  padding: 0;
+	}
 </style>


### PR DESCRIPTION
### Here is detail of modifications.

1. **Add** a new prop option `defaultImage` which is index of the expanded image, and images will occupy the same space if not value assigned. To achieve this feature, the trigger method of expand image is not via pseudo-classes but dynamicly assign class name.

2. **Remove** the function of customize class name, instead of a static class name `vue-accordion`.

3. **Simplify** the style sheet, keep original style and remove unnecessary style rules.

4. **Remove** the function of modify style with prop an object with key-value of sytle.  Now the recommend way to modify style is that overload rules from father component's style sheet with operators like `>>>` or `/deep/` ( [from vue-loader doc](https://vue-loader.vuejs.org/en/features/scoped-css.html) )

### Foward
Now expanded image will keep it until mouse hovered another image, but In some cases user need to resize the expanded image when his mouse moved out, maybe they need different modes to toggle these 2 behavior.